### PR TITLE
Adding and updating windows script

### DIFF
--- a/src/scripts/run_tests.bat
+++ b/src/scripts/run_tests.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set DIRNAME=%~dp0
+set /A NO_START=0
+
+:GETOPTS
+if /I "%1"=="-h" (
+    echo Usage: %~nx0% [-n] [-t /path/to/test/directory]
+    echo -n: do not start a new cql-translation-service container
+    exit 1
+)
+if /I "%1"=="-n" (
+    set /A NO_START = 1 & shift
+)
+if /I "%1" == "-t" set TEST_DIR=%2 & shift
+shift
+if not "%1" == "" goto GETOPTS
+
+:: Don't start new container if user wants to keep existing running server
+if %NO_START%==0 (
+    echo ^> Starting cql-translation-service
+    for /f %%i in ('docker ps ^| find "cql-translation-service"') do if not %%i==0 echo ^> Stopping existing container && docker stop %%i
+
+    docker run --name cql-translation-service --rm -d -p 8080:8080 cqframework/cql-translation-service:latest
+
+    :: Wait for cql-translation-service
+    echo ^> Waiting for server
+    :Waiting
+    echo | set /p="."
+    timeout /t 1 > nul
+    curl --silent http://localhost:8080/cql/translator > nul
+    if errorlevel 1 goto Waiting
+)
+
+echo ^> Translating CQL
+
+call node %DIRNAME%/buildElm.js
+if errorlevel 1 exit 1
+
+echo ^> Running unit tests
+
+call jest --testPathPattern=%TEST_DIR%
+
+if %NO_START%==0 (
+    echo ^> Stopping cql-translation-service
+    docker stop cql-translation-service
+)

--- a/src/scripts/run_tests.bat
+++ b/src/scripts/run_tests.bat
@@ -40,7 +40,7 @@ if errorlevel 1 exit 1
 
 echo ^> Running unit tests
 
-call jest --testPathPattern=%TEST_DIR%
+call npx jest --testPathPattern=%TEST_DIR%
 
 if %NO_START%==0 (
     echo ^> Stopping cql-translation-service

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -52,7 +52,7 @@ if [ $? -ne 0 ] ; then exit 1 ; fi
 
 echo "> Running unit tests"
 
-jest --testPathPattern=$TEST_DIR
+npx jest --testPathPattern=$TEST_DIR
 
 if [ $NO_START -eq 0 ]
 then


### PR DESCRIPTION
Adding the windows script to the now separated testing harness. This is very similar to the windows script on the mcode-cql repo, but now it takes the command line argument "-t" to specify the test folder and calls buildElm.js and jest directly instead of using the yarn scripts. You should be able to test this by changing the dependency in the mcode-cql repo (after the refactor is merged there) to point to a local file of this branch.