### PR TITLE
Better error throwing when translation fails

### DIFF
--- a/src/scripts/buildElm.js
+++ b/src/scripts/buildElm.js
@@ -63,8 +63,12 @@ async function translateCQL() {
   });
 
   if (includeCQL && Object.keys(cqlRequestBody).length > 0) {
-    const elm = await client.convertCQL(cqlRequestBody);
-    return elm;
+    const resp = await client.convertCQL(cqlRequestBody);
+    if (resp.isAxiosError) {
+      throw resp
+    }
+    // Else we have our resulting elm
+    return resp;
   }
 
   if (!includeCQL) {

--- a/src/scripts/buildElm.js
+++ b/src/scripts/buildElm.js
@@ -65,7 +65,7 @@ async function translateCQL() {
   if (includeCQL && Object.keys(cqlRequestBody).length > 0) {
     const resp = await client.convertCQL(cqlRequestBody);
     if (resp.isAxiosError) {
-      throw resp
+      throw resp;
     }
     // Else we have our resulting elm
     return resp;


### PR DESCRIPTION
Addresses STEAM-524. When the translation Client fails with an AxiosError, we throw the resulting error. This error gets caught in the high-level buildElm routine. 

To test, run translation with no translation service running. This should print the following error to the console: 
```
HTTP error translating CQL: connect ECONNREFUSED 127.0.0.1:8080
```

Additionally, you can add a syntax error to the ELM itself; this error will _not_ result in an error at the Axios level, but instead at the translation level (so long as a service is running). Accordingly, this error will be displayed in the `processError` routine.