### PR TITLE
Exit with an error code when unit tests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/src/scripts/run.js
+++ b/src/scripts/run.js
@@ -8,7 +8,13 @@ const args = process.argv.slice(2);
 const scriptBasePath = path.resolve(__dirname);
 
 if (process.platform === 'win32') {
-  spawn(path.join(scriptBasePath, 'run_tests.bat'), args, { stdio: 'inherit' });
+  const runTests = spawn(path.join(scriptBasePath, 'run_tests.bat'), args, { stdio: 'inherit' });
+  runTests.on('close', (code) => {
+    process.exit(code);
+  });
 } else {
-  spawn(path.join(scriptBasePath, 'run_tests.sh'), args, { stdio: 'inherit' });
+  const runTests = spawn(path.join(scriptBasePath, 'run_tests.sh'), args, { stdio: 'inherit' });
+  runTests.on('close', (code) => {
+    process.exit(code);
+  });
 }

--- a/src/scripts/run_tests.bat
+++ b/src/scripts/run_tests.bat
@@ -41,6 +41,7 @@ if errorlevel 1 exit 1
 echo ^> Running unit tests
 
 call npx jest --testPathPattern=%TEST_DIR%
+if errorlevel 1 exit 1
 
 if %NO_START%==0 (
     echo ^> Stopping cql-translation-service

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -54,6 +54,8 @@ echo "> Running unit tests"
 
 npx jest --testPathPattern=$TEST_DIR
 
+if [ $? -ne 0 ] ; then exit 1 ; fi
+
 if [ $NO_START -eq 0 ]
 then
   echo "> Stopping cql-translation-service"

--- a/test/execution.test.js
+++ b/test/execution.test.js
@@ -75,7 +75,7 @@ test('Should properly load multiple patient resources from array', () => {
 
 test('Should only load elm JSON with the specified identifier', () => {
   const secondElm = {
-    libray: {
+    library: {
       identifier: {
         id: 'fakeId',
         version: '1',


### PR DESCRIPTION
This PR updates the run_tests scrips to exit with exit code `1` when the unit tests fail. It also updates the `run.js` script to `process.exit` with the code the `spawn` process returns.

This change was made in order to have the GitHub Actions properly fail when unit tests are broken. Previously, unit tests would fail, but because the `run.js` process exited successfully, GitHub Actions were logging the failed tests but passing overall. This updates it so that `run.js` exits with the code from either `run_tests` script, and updates it so the `run_tests` scripts both return a nonzero error code if the tests fail.

The `cql-test-review` branch is using this branch, so you can check the GitHub actions there to test this, or you can run locally and check the error code after running failed and successful tests.